### PR TITLE
Generate config file etc/cloudkitty/cloudkitty.conf.sample when build

### DIFF
--- a/openstack-cloudkitty.spec
+++ b/openstack-cloudkitty.spec
@@ -62,6 +62,9 @@ rm -rf {test-,}requirements.txt
 %build
 %{__python} setup.py build
 
+# Generate config file etc/cloudkitty/cloudkitty.conf.sample
+PYTHONPATH=. oslo-config-generator --config-file=etc/oslo-config-generator/cloudkitty.conf
+
 %install
 %{__python} setup.py install -O1 --skip-build --root=%{buildroot}
 mkdir -p %{buildroot}/var/log/cloudkitty/


### PR DESCRIPTION
The config file etc/cloudkitty/cloudkitty.conf.sample is too hard to
maintain in openstack/cloudkitty, so this patch can fix it.